### PR TITLE
Add inputs for bsm sample production

### DIFF
--- a/inputs/bsm_preVFP_v9.txt
+++ b/inputs/bsm_preVFP_v9.txt
@@ -1,0 +1,3 @@
+/WtoNMu_MN-5_V-0p00001_TuneCP5_13TeV_madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v3/MINIAODSIM
+/WtoNMu-Ntovvv_MN-10_V-0p1_TuneCP5_13TeV_madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v3/MINIAODSIM
+/WtoNMu-Ntovvv_MN-50_V-0p1_TuneCP5_13TeV_madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v3/MINIAODSIM

--- a/scripts/makeNanoV9MCPreVFP.sh
+++ b/scripts/makeNanoV9MCPreVFP.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+if [[ $# -lt 1 ]]; then
+    echo "Requires at least one command line arguments!"
+    echo "ex. "
+    echo "    bash makeNanoV8 <das_path> (<secondary>) <name> <nthreads>"
+    exit 1
+fi
+
+das_name=$1
+nevents=1000
+name=${2}
+nThreads=${3}
+if [[ $# -gt 3 ]]; then
+    echo "Secondary files not expected for Nano V9!"
+    exit 1
+fi
+
+config_name=configs/${name}_cfg.py
+outfile=${name}.root
+
+cmsDriver.py RECO --conditions 106X_mcRun2_asymptotic_preVFP_v11 \
+    --datatier NANOAODSIM --eventcontent NANOAODSIM \
+    --era Run2_2016,run2_nanoAOD_106Xv2 \
+    --customise Configuration/DataProcessing/Utils.addMonitoring,PhysicsTools/NanoAOD/nano_cff.nanoGenWmassCustomize \
+    --filein dbs:$das_name --fileout file:$outfile --nThreads $nThreads --no_exec \
+    --python_filename $config_name --mc \
+    --scenario pp --step NANO -n $nevents 


### PR DESCRIPTION
Those samples were accidentally produced in preVFP, nevertheless we can use them at gen level. For consistency I've adapted the driver command for preVFP nano v9 